### PR TITLE
Enhance Entry TOC plugin: childrens, numbering, and blockTitleFields

### DIFF
--- a/entry-toc.php
+++ b/entry-toc.php
@@ -6,7 +6,8 @@ return [
     'fieldsToIndex' => [
         [
             'fieldHandle' => 'exampleNeoField', 
-            'fieldTitles' => ['exampleHeading']
+            'fieldTitles' => ['exampleHeading'],
+            'numbering' => false
         ],
         [
             'fieldHandle' => 'exampleMatrixField',

--- a/entry-toc.php
+++ b/entry-toc.php
@@ -7,7 +7,8 @@ return [
         [
             'fieldHandle' => 'exampleNeoField', 
             'fieldTitles' => ['exampleHeading'],
-            'numbering' => false
+            'numbering' => false,
+            'blockTitleFields' => ['exampleBlockField', 'exampleBlockField']
         ],
         [
             'fieldHandle' => 'exampleMatrixField',

--- a/src/assetbundles/dist/css/SidebarCss.css
+++ b/src/assetbundles/dist/css/SidebarCss.css
@@ -7,6 +7,14 @@
     padding-bottom: 0.25rem;
 }
 
+.accordion-item-body-content ul {
+    padding-left: 1.5rem;
+}
+
+.accordion-item-body-content ul li {
+    list-style-type: circle;
+}
+
 .accordion {
     margin: auto auto 1rem auto;
     max-width: 1000px;
@@ -44,7 +52,7 @@
 }
 .accordion-item-body {
     max-height: 0;
-    overflow: hidden;
+    overflow-y: auto;
     transition: max-height 0.2s ease-out;
 }
 .accordion-item-body-content {

--- a/src/assetbundles/dist/css/SidebarCss.css
+++ b/src/assetbundles/dist/css/SidebarCss.css
@@ -2,6 +2,10 @@
     padding: 1rem 1rem 1rem 2.1rem;
 }
 
+.accordion-item-body > ol {
+    padding: 1rem 1rem 1rem 2.1rem;
+}
+
 .accordion-item-body > ul > li {
     list-style-type: circle;
     padding-bottom: 0.25rem;
@@ -9,6 +13,18 @@
 
 .accordion-item-body-content ul {
     padding-left: 1.5rem;
+}
+
+.accordion-item-body-content ol {
+    list-style-type: none;
+}
+
+.accordion-item-body > ol > li {
+    list-style-type: none;
+}
+
+.accordion-item-body > ol > li {
+    padding-bottom: 0.25rem;
 }
 
 .accordion-item-body-content ul li {

--- a/src/assetbundles/dist/css/SidebarCss.css
+++ b/src/assetbundles/dist/css/SidebarCss.css
@@ -1,5 +1,5 @@
 .accordion-item-body > ul {
-    padding: 0 1rem 1rem 2.1rem;
+    padding: 1rem 1rem 1rem 2.1rem;
 }
 
 .accordion-item-body > ul > li {
@@ -12,9 +12,8 @@
     max-width: 1000px;
 }
 .accordion-item {
-    background-color: #fff;
+    background-color: #f3f7fc;
     border-radius: 0.5rem;
-    box-shadow: 0 2px 5px 0 rgba(0,0,0,0.25);
     color: #111;
     margin: 1rem 0;
 }
@@ -27,6 +26,10 @@
     min-height: 3.5rem;
     padding: 0.5rem 3rem 0.5rem 1rem;
     position: relative;
+    box-shadow:
+    0 0 0 1px #cdd8e4,
+    0 2px 12px rgba(205, 216, 228, 0.5);
+    border-radius: 0.5rem;
 }
 .accordion-item-header::after {
     color: var(--medium-text-color);
@@ -45,9 +48,5 @@
     transition: max-height 0.2s ease-out;
 }
 .accordion-item-body-content {
-    
-
     line-height: 1.5rem;
-    border-top: 1px solid;
-    border-image: linear-gradient(to right, transparent, #34495e, transparent) 1;
 }

--- a/src/assetbundles/dist/js/SidebarJs.js
+++ b/src/assetbundles/dist/js/SidebarJs.js
@@ -25,22 +25,26 @@ function toggleToc(hideAll) {
     })
 }
 
-const accordionItemHeaders = document.querySelectorAll(".accordion-item-header");
+const accordionItemHeaders = document.querySelectorAll(
+  ".accordion-item-header",
+);
 
-accordionItemHeaders.forEach(accordionItemHeader => {
-  accordionItemHeader.addEventListener("click", event => {
-    
-    accordionItemHeader.classList.toggle("active");
-    const accordionItemBody = accordionItemHeader.nextElementSibling;
-    if(accordionItemHeader.classList.contains("active")) {
-      accordionItemBody.style.maxHeight = accordionItemBody.scrollHeight + "px";
+accordionItemHeaders.forEach((header) => {
+  header.addEventListener("click", () => {
+    header.classList.toggle("active");
+    const body = header.nextElementSibling;
+
+    if (header.classList.contains("active")) {
+      const maxHeight = window.innerHeight * 0.8;
+      const contentHeight = body.scrollHeight;
+
+      body.style.maxHeight = Math.min(contentHeight, maxHeight) + "px";
+    } else {
+      body.style.maxHeight = 0;
     }
-    else {
-      accordionItemBody.style.maxHeight = 0;
-    }
-    
   });
 });
+
 
 let tocs = document.querySelectorAll(".toc");
 if (tocs[0].closest(".slideout-container")) {

--- a/src/templates/_sidebar.twig
+++ b/src/templates/_sidebar.twig
@@ -22,20 +22,32 @@
                            <div class="accordion-item-body">
 
                                 {% macro renderBlocks(blocks, field, prefix) %}
-                                    {% if field.numbering %}
+                                    {% set numbering = field.numbering|default(false) %}
+
+                                    {% if numbering %}
                                         <ol class="accordion-item-body-content">
                                     {% else %}
                                         <ul class="accordion-item-body-content">
                                     {% endif %}
 
                                     {% for block in blocks %}
-                                        {% set itemTitle = _self.getTitle(block, field) %}
+                                        {% set itemTitle = block.type.name %}
 
-                                        {% set number = field.numbering ? (prefix ? prefix ~ '.' ~ loop.index : loop.index) : '' %}
+                                        {% set titleFound = false %}
+                                        {% if field.blockTitleFields is defined %}
+                                            {% for f in field.blockTitleFields %}
+                                                {% if not titleFound and block[f] is defined and block[f] %}
+                                                    {% set itemTitle = itemTitle ~ ' (' ~ block[f]|striptags ~ ')' %}
+                                                    {% set titleFound = true %}
+                                                {% endif %}
+                                            {% endfor %}
+                                        {% endif %}
+
+                                        {% set number = numbering ? (prefix ? prefix ~ '.' ~ loop.index : loop.index) : '' %}
 
                                         <li>
                                             <a href="#{{ block.id }}" class="tocitem" id="toc{{ block.id }}">
-                                                {% if field.numbering %}{{ number }}. {% endif %}
+                                                {% if numbering %}{{ number }}. {% endif %}
                                                 {{ itemTitle }}
                                             </a>
 
@@ -46,7 +58,7 @@
 
                                     {% endfor %}
 
-                                    {% if field.numbering %}
+                                    {% if numbering %}
                                         </ol>
                                     {% else %}
                                         </ul>

--- a/src/templates/_sidebar.twig
+++ b/src/templates/_sidebar.twig
@@ -20,7 +20,7 @@
                         </div>
                         {% if fieldObj.className == "benf\\neo\\Field" %}
                             <div class="accordion-item-body">
-                                <ul class="accorion-item-body-content">
+                                <ul class="accordion-item-body-content">
                                     {% for block in indexField.level(1).all() %}
                                         {% set itemTitle = macros.getTitle(block, field) %}
                                         <li>
@@ -31,7 +31,7 @@
                             </div>
                         {% elseif fieldObj.className == "craft\\fields\\Matrix" %}
                             <div class="accordion-item-body">
-                                <ul class="accorion-item-body-content">
+                                <ul class="accordion-item-body-content">
                                     {% for block in indexField.all() %}
                                         {% set itemTitle = macros.getTitle(block, field) %}
                                         <li>

--- a/src/templates/_sidebar.twig
+++ b/src/templates/_sidebar.twig
@@ -20,14 +20,28 @@
                         </div>
                         {% if fieldObj.className == "benf\\neo\\Field" %}
                             <div class="accordion-item-body">
-                                <ul class="accordion-item-body-content">
-                                    {% for block in indexField.level(1).all() %}
-                                        {% set itemTitle = macros.getTitle(block, field) %}
-                                        <li>
-                                            <a href="#{{ block.id }}" class="tocitem" id="toc{{ block.id }}">{{ itemTitle }}</a>
-                                        </li>
-                                    {% endfor %}
-                                </ul>
+
+                                {% macro renderBlocks(blocks, field) %}
+                                    <ul class="accordion-item-body-content">
+                                        {% for block in blocks %}
+                                            {% set itemTitle = _self.getTitle(block, field) %}
+
+                                            <li>
+                                                <a href="#{{ block.id }}" class="tocitem" id="toc{{ block.id }}">
+                                                    {{ itemTitle }}
+                                                </a>
+
+                                                {% if block.children|length %}
+                                                    {{ _self.renderBlocks(block.children.all(), field) }}
+                                                {% endif %}
+                                            </li>
+
+                                        {% endfor %}
+                                    </ul>
+                                {% endmacro %}
+
+                                {{ macros.renderBlocks(indexField.level(1).all(), field) }}
+
                             </div>
                         {% elseif fieldObj.className == "craft\\fields\\Matrix" %}
                             <div class="accordion-item-body">

--- a/src/templates/_sidebar.twig
+++ b/src/templates/_sidebar.twig
@@ -19,28 +19,41 @@
                             <h4>{{ fieldObj.name }} Table of Contents</h4>
                         </div>
                         {% if fieldObj.className == "benf\\neo\\Field" %}
-                            <div class="accordion-item-body">
+                           <div class="accordion-item-body">
 
-                                {% macro renderBlocks(blocks, field) %}
-                                    <ul class="accordion-item-body-content">
-                                        {% for block in blocks %}
-                                            {% set itemTitle = _self.getTitle(block, field) %}
+                                {% macro renderBlocks(blocks, field, prefix) %}
+                                    {% if field.numbering %}
+                                        <ol class="accordion-item-body-content">
+                                    {% else %}
+                                        <ul class="accordion-item-body-content">
+                                    {% endif %}
 
-                                            <li>
-                                                <a href="#{{ block.id }}" class="tocitem" id="toc{{ block.id }}">
-                                                    {{ itemTitle }}
-                                                </a>
+                                    {% for block in blocks %}
+                                        {% set itemTitle = _self.getTitle(block, field) %}
 
-                                                {% if block.children|length %}
-                                                    {{ _self.renderBlocks(block.children.all(), field) }}
-                                                {% endif %}
-                                            </li>
+                                        {% set number = field.numbering ? (prefix ? prefix ~ '.' ~ loop.index : loop.index) : '' %}
 
-                                        {% endfor %}
-                                    </ul>
+                                        <li>
+                                            <a href="#{{ block.id }}" class="tocitem" id="toc{{ block.id }}">
+                                                {% if field.numbering %}{{ number }}. {% endif %}
+                                                {{ itemTitle }}
+                                            </a>
+
+                                            {% if block.children|length %}
+                                                {{ _self.renderBlocks(block.children.all(), field, number) }}
+                                            {% endif %}
+                                        </li>
+
+                                    {% endfor %}
+
+                                    {% if field.numbering %}
+                                        </ol>
+                                    {% else %}
+                                        </ul>
+                                    {% endif %}
                                 {% endmacro %}
 
-                                {{ macros.renderBlocks(indexField.level(1).all(), field) }}
+                                {{ macros.renderBlocks(indexField.level(1).all(), field, '') }}
 
                             </div>
                         {% elseif fieldObj.className == "craft\\fields\\Matrix" %}


### PR DESCRIPTION
This PR introduces several improvements to the Entry TOC plugin:

1. **Fixed accordion item class names**  
   - Corrected previously mistyped class names for proper styling.

2. **Support for nested Neo blocks (children)**  
   - TOC now recursively renders child blocks, maintaining hierarchy.

3. **Optional numbering for blocks**  
   - Blocks can now be numbered (1, 1.1, 1.1.1…) based on the `numbering` config option.  
   - Default behavior remains bullet list if `numbering` is false.

4. **Display additional block title fields**  
   - Configurable via `blockTitleFields` (e.g., `['title', 'headline']`)  
   - Only the first available field value is displayed in parentheses next to the block type.  
   - Fields not defined or empty are ignored.